### PR TITLE
Changing vars around, changing DNS and adding prod peering connections.

### DIFF
--- a/env_configs/common.tfvars
+++ b/env_configs/common.tfvars
@@ -1,1 +1,10 @@
-bastion_domain_zone = "bastion.probation.hmpps.dsd.io."
+# VPC variables
+cloudwatch_log_retention = 14
+
+availability_zone = {
+  az1 = "eu-west-2a"
+
+  az2 = "eu-west-2b"
+
+  az3 = "eu-west-2c"
+}

--- a/env_configs/dev.tfvars
+++ b/env_configs/dev.tfvars
@@ -1,17 +1,4 @@
-# This is used for ALB logs to S3 bucket.
-# This is fixed for each region. if region changes, this changes
-lb_account_id = "652711504416"
-
-# VPC variables
-cloudwatch_log_retention = 14
-
-availability_zone = {
-  az1 = "eu-west-2a"
-
-  az2 = "eu-west-2b"
-
-  az3 = "eu-west-2c"
-}
+bastion_domain_zone = "bastion-dev.probation.hmpps.dsd.io."
 
 bastion_cidr_block = "10.161.98.0/25"
 

--- a/env_configs/prod.tfvars
+++ b/env_configs/prod.tfvars
@@ -1,17 +1,4 @@
-# This is used for ALB logs to S3 bucket.
-# This is fixed for each region. if region changes, this changes
-lb_account_id = "652711504416"
-
-# VPC variables
-cloudwatch_log_retention = 14
-
-availability_zone = {
-  az1 = "eu-west-2a"
-
-  az2 = "eu-west-2b"
-
-  az3 = "eu-west-2c"
-}
+bastion_domain_zone = "bastion-prod.probation.hmpps.dsd.io."
 
 bastion_cidr_block = "10.160.98.0/25"
 
@@ -30,4 +17,6 @@ bastion_public_cidr = {
 ## to be destroyed and recreated.
 
 bastion_peering_ids = [
+  "pcx-038d6208ed97d819f,10.160.65.0/24,vcms-preprod",
+  "pcx-082a17dcacd503d98,10.160.64.0/24,vcms-prod",
 ]

--- a/service-bastion/dns.tf
+++ b/service-bastion/dns.tf
@@ -6,7 +6,7 @@ data "aws_route53_zone" "zone" {
 
 resource "aws_route53_record" "bastion" {
   zone_id = "${data.aws_route53_zone.zone.zone_id}"
-  name    = "${var.environment}"
+  name    = "ssh"
   type    = "A"
   ttl     = "300"
   records = ["${aws_eip.bastion_eip.public_ip}"]

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -21,6 +21,7 @@ terragrunt = {
         "import",
         "push",
         "refresh",
+        "apply",
       ]
 
       arguments = [


### PR DESCRIPTION
Adding the peering connections for VCMS production.

Moving some vars to common that should be there and removing DNS.

DNS has changed to using a different subdomain for prod and dev as these
both live in different accounts.

This will mean the following are the bastion hostnames.

ssh.bastion-dev.probation.hmpps.dsd.io
ssh.bastion-prod.probation.hmpps.dsd.io

The production domain should be later changed to be under the
service.justice.gov.uk domain to remove the dependency on dsd.io