### PR TITLE
Issue54 dam 333 extend vpc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
               slackSend(message: "\"Apply\" started on ${environment_name} Bastion/Access - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL.replace(':8080','')}|Open>)")
 
               dir( project.bastion_access ) {
-                git url: 'git@github.com:ministryofjustice/' + project.bastion_access, branch: 'issue54_DAM-333_Exetend_VPC', credentialsId: 'f44bc5f1-30bd-4ab9-ad61-cc32caf1562a'
+                git url: 'git@github.com:ministryofjustice/' + project.bastion_access, branch: 'master', credentialsId: 'f44bc5f1-30bd-4ab9-ad61-cc32caf1562a'
               }
 
               prepare_env()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def project = [:]
-project.eng_platform  = 'hmpps-engineering-platform-terraform'
+project.bastion_access  = 'hmpps-delius-bastion'
 
 // Parameters required for job
 // parameters:
@@ -140,7 +140,9 @@ pipeline {
 
               slackSend(message: "\"Apply\" started on ${environment_name} Bastion/Access - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL.replace(':8080','')}|Open>)")
 
-              checkout scm
+              dir( project.eng_platform ) {
+                git url: 'git@github.com:ministryofjustice/' + project.bastion_access, branch: 'issue54_DAM-333_Exetend_VPC', credentialsId: 'f44bc5f1-30bd-4ab9-ad61-cc32caf1562a'
+              }
 
               prepare_env()
             }
@@ -148,19 +150,19 @@ pipeline {
 
         stage('Network') {
             steps {
-                do_terraform('bastion-vpc')
+                do_terraform(environment_name, project.bastion_access, 'bastion-vpc')
             }
         }
 
         stage('Routes') {
             steps {
-                do_terraform('routes')
+                do_terraform(environment_name, project.bastion_access, 'routes')
             }
         }
 
         stage('Service') {
             steps {
-                do_terraform('service-bastion')
+                do_terraform(environment_name, project.bastion_access, 'service-bastion')
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,6 @@ def plan_submodule(env_name, git_project_dir, submodule_name) {
             -v ~/.aws:/home/tools/.aws mojdigitalstudio/hmpps-terraform-builder \
             bash -c "\
                 source env_configs/${env_name}.properties; \
-                if [ '${env_name}' == 'dev' ]; then unset TERRAGRUNT_IAM_ROLE; fi; \
                 cd ${submodule_name}; \
                 if [ -d .terraform ]; then rm -rf .terraform; fi; sleep 5; \
                 terragrunt init; \
@@ -63,7 +62,6 @@ def apply_submodule(env_name, git_project_dir, submodule_name) {
           -v ~/.aws:/home/tools/.aws mojdigitalstudio/hmpps-terraform-builder \
           bash -c " \
               source env_configs/${env_name}.properties; \
-              if [ '${env_name}' == 'dev' ]; then unset TERRAGRUNT_IAM_ROLE; fi; \
               cd ${submodule_name}; \
               terragrunt apply ${env_name}.plan; \
               tgexitcode=\\\$?; \
@@ -140,7 +138,7 @@ pipeline {
 
               slackSend(message: "\"Apply\" started on ${environment_name} Bastion/Access - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL.replace(':8080','')}|Open>)")
 
-              dir( project.eng_platform ) {
+              dir( project.bastion_access ) {
                 git url: 'git@github.com:ministryofjustice/' + project.bastion_access, branch: 'issue54_DAM-333_Exetend_VPC', credentialsId: 'f44bc5f1-30bd-4ab9-ad61-cc32caf1562a'
               }
 

--- a/bastion-vpc/main.tf
+++ b/bastion-vpc/main.tf
@@ -68,6 +68,40 @@ module "bastion-public-az3" {
   tags                    = "${var.tags}"
 }
 
+############################################
+# PRIVATE SUBNET
+############################################
+
+module "bastion-private-az1" {
+  source                  = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//subnets"
+  subnet_cidr_block       = "${var.bastion_private_cidr["az1"]}"
+  availability_zone       = "${var.availability_zone["az1"]}"
+  map_public_ip_on_launch = "false"
+  subnet_name             = "${var.environment_identifier}-publicaz1"
+  vpc_id                  = "${module.bastion_vpc.vpc_id}"
+  tags                    = "${var.tags}"
+}
+
+module "bastion-private-az2" {
+  source                  = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//subnets"
+  subnet_cidr_block       = "${var.bastion_private_cidr["az2"]}"
+  availability_zone       = "${var.availability_zone["az2"]}"
+  map_public_ip_on_launch = "false"
+  subnet_name             = "${var.environment_identifier}-publicaz2"
+  vpc_id                  = "${module.bastion_vpc.vpc_id}"
+  tags                    = "${var.tags}"
+}
+
+module "bastion-private-az3" {
+  source                  = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//subnets"
+  subnet_cidr_block       = "${var.bastion_private_cidr["az3"]}"
+  availability_zone       = "${var.availability_zone["az3"]}"
+  map_public_ip_on_launch = "false"
+  subnet_name             = "${var.environment_identifier}-publicaz3"
+  vpc_id                  = "${module.bastion_vpc.vpc_id}"
+  tags                    = "${var.tags}"
+}
+
 ##########################
 #  VPC FLOW LOGS
 ##########################
@@ -153,4 +187,26 @@ module "route-to-internet" {
   ]
 
   gateway_id = "${module.bastion_igw.igw_id}"
+}
+
+## NATGATEWAY
+module "common-nat-az1" {
+  source = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//natgateway"
+  az     = "${var.environment_identifier}-az1"
+  subnet = "${module.bastion-private-az1.subnetid}"
+  tags   = "${var.tags}"
+}
+
+module "common-nat-az2" {
+  source = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules/natgateway"
+  az     = "${var.environment_identifier}-az2"
+  subnet = "${module.bastion-private-az2.subnetid}"
+  tags   = "${var.tags}"
+}
+
+module "common-nat-az3" {
+  source = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules/natgateway"
+  az     = "${var.environment_identifier}-az3"
+  subnet = "${module.bastion-private-az3.subnetid}"
+  tags   = "${var.tags}"
 }

--- a/bastion-vpc/main.tf
+++ b/bastion-vpc/main.tf
@@ -77,7 +77,7 @@ module "bastion-private-az1" {
   subnet_cidr_block       = "${var.bastion_private_cidr["az1"]}"
   availability_zone       = "${var.availability_zone["az1"]}"
   map_public_ip_on_launch = "false"
-  subnet_name             = "${var.environment_identifier}-publicaz1"
+  subnet_name             = "${var.environment_identifier}-private-az1"
   vpc_id                  = "${module.bastion_vpc.vpc_id}"
   tags                    = "${var.tags}"
 }
@@ -87,7 +87,7 @@ module "bastion-private-az2" {
   subnet_cidr_block       = "${var.bastion_private_cidr["az2"]}"
   availability_zone       = "${var.availability_zone["az2"]}"
   map_public_ip_on_launch = "false"
-  subnet_name             = "${var.environment_identifier}-publicaz2"
+  subnet_name             = "${var.environment_identifier}-private-az2"
   vpc_id                  = "${module.bastion_vpc.vpc_id}"
   tags                    = "${var.tags}"
 }
@@ -97,7 +97,7 @@ module "bastion-private-az3" {
   subnet_cidr_block       = "${var.bastion_private_cidr["az3"]}"
   availability_zone       = "${var.availability_zone["az3"]}"
   map_public_ip_on_launch = "false"
-  subnet_name             = "${var.environment_identifier}-publicaz3"
+  subnet_name             = "${var.environment_identifier}-private-az3"
   vpc_id                  = "${module.bastion_vpc.vpc_id}"
   tags                    = "${var.tags}"
 }

--- a/bastion-vpc/output.tf
+++ b/bastion-vpc/output.tf
@@ -53,6 +53,42 @@ output "public-routetable-az2" {
 output "public-routetable-az3" {
   value = "${module.bastion-public-az3.routetableid}"
 }
+##
+output "bastion-private-subnet-az1" {
+  value = "${module.bastion-private-az1.subnetid}"
+}
+
+output "bastion-private-subnet-az2" {
+  value = "${module.bastion-private-az2.subnetid}"
+}
+
+output "bastion-private-subnet-az3" {
+  value = "${module.bastion-private-az3.subnetid}"
+}
+
+output "private-routetable-az1" {
+  value = "${module.bastion-private-az1.routetableid}"
+}
+
+output "private-routetable-az2" {
+  value = "${module.bastion-private-az2.routetableid}"
+}
+
+output "private-routetable-az3" {
+  value = "${module.bastion-private-az3.routetableid}"
+}
+# ##
+output "common-nat-id-az1" {
+  value = "${module.common-nat-az1.natid}"
+}
+
+output "common-nat-id-az2" {
+  value = "${module.common-nat-az2.natid}"
+}
+
+output "common-nat-id-az3" {
+  value = "${module.common-nat-az3.natid}"
+}
 
 # S3 Buckets
 output "s3-config-bucket" {

--- a/bastion-vpc/output.tf
+++ b/bastion-vpc/output.tf
@@ -1,3 +1,14 @@
+output "vpc" {
+  value = {
+      account_id   = "${data.aws_caller_identity.current.account_id}",
+      id           = "${module.bastion_vpc.vpc_id}",
+      cidr         = "${module.bastion_vpc.vpc_cidr}",
+      public_cidr  = "${var.bastion_public_cidr}",
+      private_cidr = "${var.bastion_private_cidr}",
+      peer_accepter_prefix  = "${local.peer_accepter_prefix}"
+    }
+}
+
 output "bastion_vpc_account_id" {
   value = "${data.aws_caller_identity.current.account_id}"
 }

--- a/bastion-vpc/peering.tf
+++ b/bastion-vpc/peering.tf
@@ -1,8 +1,19 @@
+locals {
+  peer_accepter_prefix  = "${var.environment_name}"
+}
+
+
 resource "aws_vpc_peering_connection_accepter" "peer" {
   count = "${length(var.bastion_peering_ids)}"
   vpc_peering_connection_id = "${element(split(",", var.bastion_peering_ids[count.index] ), 0)}"
   auto_accept = true
-  tags = "${merge(var.tags, map("Name", "${var.short_environment_identifier}-from-${element(split(",", var.bastion_peering_ids[count.index] ), 2)}-vpc"))}"
+  tags = "${merge(var.tags,
+      map("Name", "${local.peer_accepter_prefix}-from-${element(split(",", var.bastion_peering_ids[count.index] ), 2)}-vpc"),
+      map("project", "${element(split(",", var.bastion_peering_ids[count.index] ), 2)}"),
+      map("bastion_inventory", "not applicable"),
+      map("environment-name", "${local.peer_accepter_prefix}-from-${element(split(",", var.bastion_peering_ids[count.index] ), 2)}-vpc")
+    )}"
+
 }
 
 resource "aws_route" "peer_route_az1" {

--- a/bastion-vpc/variables.tf
+++ b/bastion-vpc/variables.tf
@@ -14,6 +14,8 @@ variable "short_environment_identifier" {
   description = "short resource label or name"
 }
 
+variable "environment_name" {}
+
 variable "tags" {
   type = "map"
 }

--- a/bastion-vpc/variables.tf
+++ b/bastion-vpc/variables.tf
@@ -30,6 +30,10 @@ variable "bastion_public_cidr" {
   type = "map"
 }
 
+variable "bastion_private_cidr" {
+  type = "map"
+}
+
 variable "bastion_domain_zone" {}
 
 variable "cloudwatch_log_retention" {}

--- a/env_configs/dev.properties
+++ b/env_configs/dev.properties
@@ -28,6 +28,8 @@ export TG_ENVIRONMENT_IDENTIFIER="tf-${TG_REGION}-${TG_BUSINESS_UNIT}-${TG_PROJE
 
 export TG_SHORT_ENVIRONMENT_IDENTIFIER="tf-${TG_BUSINESS_UNIT}-${TG_PROJECT}-${TG_ENVIRONMENT}"
 
+export TG_ENVIRONMENT_NAME="${TG_PROJECT}-${TG_ENVIRONMENT}"
+
 # REMOTE_STATE_BUCKET
 export TG_REMOTE_STATE_BUCKET="${TG_ENVIRONMENT_IDENTIFIER}-remote-state"
 
@@ -51,6 +53,8 @@ export TF_VAR_is_production=${IS_PRODUCTION}
 export TF_VAR_environment_identifier=${TG_ENVIRONMENT_IDENTIFIER}
 
 export TF_VAR_short_environment_identifier=${TG_SHORT_ENVIRONMENT_IDENTIFIER}
+
+export TF_VAR_environment_name=${TG_ENVIRONMENT_NAME}
 
 export TF_VAR_remote_state_bucket_name=${TG_REMOTE_STATE_BUCKET}
 

--- a/env_configs/dev.tfvars
+++ b/env_configs/dev.tfvars
@@ -10,6 +10,14 @@ bastion_public_cidr = {
   az3 = "10.161.98.32/28"
 }
 
+bastion_private_cidr = {
+  az1 = "10.161.98.64/27"
+
+  az2 = "10.161.98.96/27"
+
+  az3 = "10.161.98.48/28"
+}
+
 # In the format of peering_id,subnet
 
 ## NOTE: Add new items to end of list.

--- a/env_configs/dev.tfvars
+++ b/env_configs/dev.tfvars
@@ -38,7 +38,7 @@ bastion_peering_ids = [
   "pcx-0e74f31beaf9d280c,10.161.75.0/24,alfresco-dev",
   "pcx-0ecec4aab0056807e,10.161.79.0/24,mis-nart-test",
   "pcx-0a8f180e3124621e9,10.161.80.0/24,alfresco-sbx",
-  "pcx-08e9c692686409f51,10.161.96.0/24,eng-dev",
+  "pcx-08e9c692686409f51,10.161.96.0/24,engineering-dev",
   "pcx-0cc74edb3f9503931,10.162.48.0/20,delius-po-test1",
   "pcx-05baa6df601a10ff1,10.162.64.0/20,delius-po-test2",
   "pcx-0ffe096b1766c58f8,10.162.96.0/20,delius-training",

--- a/env_configs/prod.properties
+++ b/env_configs/prod.properties
@@ -28,6 +28,8 @@ export TG_ENVIRONMENT_IDENTIFIER="tf-${TG_REGION}-${TG_BUSINESS_UNIT}-${TG_PROJE
 
 export TG_SHORT_ENVIRONMENT_IDENTIFIER="tf-${TG_BUSINESS_UNIT}-${TG_PROJECT}-${TG_ENVIRONMENT}"
 
+export TG_ENVIRONMENT_NAME="${TG_PROJECT}-${TG_ENVIRONMENT}"
+
 # REMOTE_STATE_BUCKET
 export TG_REMOTE_STATE_BUCKET="${TG_ENVIRONMENT_IDENTIFIER}-remote-state"
 
@@ -51,6 +53,8 @@ export TF_VAR_is_production=${IS_PRODUCTION}
 export TF_VAR_environment_identifier=${TG_ENVIRONMENT_IDENTIFIER}
 
 export TF_VAR_short_environment_identifier=${TG_SHORT_ENVIRONMENT_IDENTIFIER}
+
+export TF_VAR_environment_name=${TG_ENVIRONMENT_NAME}
 
 export TF_VAR_remote_state_bucket_name=${TG_REMOTE_STATE_BUCKET}
 

--- a/env_configs/prod.tfvars
+++ b/env_configs/prod.tfvars
@@ -30,5 +30,5 @@ bastion_peering_ids = [
   "pcx-0a3ec95ee58916ddc,10.160.96.0/24,engineering-prod",
   "pcx-09157c7b0c3198eb5,10.160.0.0/20,delius-pre-prod",
   "pcx-03373232955f8d862,10.160.16.0/20,delius-prod",
-  "pcx-08e9c692686409f51,10.161.96.0/24,engineering-dev",
+  "pcx-0913df32be8acaa55,10.161.96.0/24,engineering-dev",
 ]

--- a/env_configs/prod.tfvars
+++ b/env_configs/prod.tfvars
@@ -10,6 +10,14 @@ bastion_public_cidr = {
   az3 = "10.160.98.32/28"
 }
 
+bastion_private_cidr = {
+  az1 = "10.160.98.64/27"
+
+  az2 = "10.160.98.96/27"
+
+  az3 = "10.160.98.48/28"
+}
+
 # In the format of peering_id,subnet
 
 ## NOTE: Add new items to end of list.

--- a/env_configs/prod.tfvars
+++ b/env_configs/prod.tfvars
@@ -27,7 +27,8 @@ bastion_private_cidr = {
 bastion_peering_ids = [
   "pcx-00201b8d5b70f847b,10.160.65.0/24,vcms-preprod",
   "pcx-062639fa322e975bf,10.160.64.0/24,vcms-prod",
-  "pcx-0a3ec95ee58916ddc,10.160.96.0/24,eng-prod",
+  "pcx-0a3ec95ee58916ddc,10.160.96.0/24,engineering-prod",
   "pcx-09157c7b0c3198eb5,10.160.0.0/20,delius-pre-prod",
   "pcx-03373232955f8d862,10.160.16.0/20,delius-prod",
+  "pcx-08e9c692686409f51,10.161.96.0/24,engineering-dev",
 ]

--- a/routes/main.tf
+++ b/routes/main.tf
@@ -27,9 +27,9 @@ module "route-private-to-nat" {
   source = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//routes//natgateway"
 
   route_table_id = [
-    "${data.vpc.private-routetable-az1}",
-    "${data.vpc.private-routetable-az2}",
-    "${data.vpc.private-routetable-az3}"
+    "${data.terraform_remote_state.vpc.private-routetable-az1}",
+    "${data.terraform_remote_state.vpc.private-routetable-az2}",
+    "${data.terraform_remote_state.vpc.private-routetable-az3}"
   ]
 
   destination_cidr_block = [
@@ -39,8 +39,8 @@ module "route-private-to-nat" {
   ]
 
   nat_gateway_id = [
-    "${data.vpc.common-nat-id-az1}",
-    "${data.vpc.common-nat-id-az2}",
-    "${data.vpc.common-nat-id-az3}"
+    "${data.terraform_remote_state.vpc.common-nat-id-az1}",
+    "${data.terraform_remote_state.vpc.common-nat-id-az2}",
+    "${data.terraform_remote_state.vpc.common-nat-id-az3}"
   ]
 }

--- a/routes/main.tf
+++ b/routes/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "s3" {}
+}
+
+provider "aws" {
+  region  = "${var.region}"
+  version = "~> 1.16"
+}
+
+####################################################
+# DATA SOURCE MODULES FROM OTHER TERRAFORM BACKENDS
+####################################################
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket_name}"
+    key    = "bastion-vpc/terraform.tfstate"
+    region = "${var.region}"
+  }
+}
+
+# ## ROUTES to NATGATEWAY
+
+module "route-private-to-nat" {
+  source = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//routes//natgateway"
+
+  route_table_id = [
+    "${data.vpc.private-routetable-az1}",
+    "${data.vpc.private-routetable-az2}",
+    "${data.vpc.private-routetable-az3}"
+  ]
+
+  destination_cidr_block = [
+    "0.0.0.0/0",
+    "0.0.0.0/0",
+    "0.0.0.0/0",
+  ]
+
+  nat_gateway_id = [
+    "${data.vpc.common-nat-id-az1}",
+    "${data.vpc.common-nat-id-az2}",
+    "${data.vpc.common-nat-id-az3}"
+  ]
+}

--- a/routes/output.tf
+++ b/routes/output.tf
@@ -1,12 +1,1 @@
-##
-output "common-nat-id-az1" {
-  value = "${module.common-nat-az1.natid}"
-}
 
-output "common-nat-id-az2" {
-  value = "${module.common-nat-az2.natid}"
-}
-
-output "common-nat-id-az3" {
-  value = "${module.common-nat-az3.natid}"
-}

--- a/routes/output.tf
+++ b/routes/output.tf
@@ -1,0 +1,12 @@
+##
+output "common-nat-id-az1" {
+  value = "${module.common-nat-az1.natid}"
+}
+
+output "common-nat-id-az2" {
+  value = "${module.common-nat-az2.natid}"
+}
+
+output "common-nat-id-az3" {
+  value = "${module.common-nat-az3.natid}"
+}

--- a/routes/terraform.tfvars
+++ b/routes/terraform.tfvars
@@ -1,0 +1,10 @@
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+
+  dependencies {
+    paths = ["../bastion-vpc"]
+  }
+
+}

--- a/routes/variables.tf
+++ b/routes/variables.tf
@@ -1,0 +1,7 @@
+variable "region" {
+  description = "The AWS region."
+}
+
+variable "remote_state_bucket_name" {
+  description = "Terraform remote state bucket name"
+}


### PR DESCRIPTION
Closes #54 

Aligns Jenkins file with those used elsewhere, added Slack messages, ability to ignore apply prompt (default is prompt).

Extends the VPC with private subnets utilising the remainder of the overall CIDR.

VPC peering acceptance no longer renames tags and peering "Name" when requester terraform code is run.
Additional peering acceptance for engineering-dev VPC to bastion-prod.