### PR TITLE
Remove the dev bastion peering with PERF

### DIFF
--- a/env_configs/dev.tfvars
+++ b/env_configs/dev.tfvars
@@ -32,7 +32,6 @@ bastion_peering_ids = [
   "pcx-089ec396b50a4662b,10.161.20.0/22,delius-core-dev",
   "pcx-088f1f4fb40cea44a,10.161.73.0/24,delius-new-tech-dev",
   "pcx-0cc5e82fe8f726785,10.162.0.0/20,delius-test",
-  "pcx-020091becf6f4fc01,10.162.16.0/20,delius-perf",
   "pcx-0d129c7968ddb1a26,10.161.4.0/22,delius-core-sandpit",
   "pcx-0e74f31beaf9d280c,10.161.75.0/24,alfresco-dev",
   "pcx-0a8f180e3124621e9,10.161.80.0/24,alfresco-sbx",

--- a/env_configs/prod.tfvars
+++ b/env_configs/prod.tfvars
@@ -31,4 +31,5 @@ bastion_peering_ids = [
   "pcx-03373232955f8d862,10.160.16.0/20,delius-prod",
   "pcx-0913df32be8acaa55,10.161.96.0/24,engineering-dev",
   "pcx-0a5d2629588eaeea7,10.160.32.0/20,delius-stage",
+  "pcx-074d66c2c52980e1b,10.160.48.0/20,delius-perf",
 ]


### PR DESCRIPTION
Add the prod bastion peering with PERF
because PERF is going to be accessed via the PROD bastion due to having production data.