### PR TITLE
Adding role and instance profile to enable SSM connections

### DIFF
--- a/service-bastion/iam.tf
+++ b/service-bastion/iam.tf
@@ -1,0 +1,41 @@
+locals {
+  instance_role_name = "SSMBastionAccess"
+}
+
+# Derive assume permissions
+data "aws_iam_policy_document" "instance_iam_role_assume_permissions" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts.AssumeRole"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# Define IAM role
+resource "aws_iam_role" "instance_iam_role" {
+  name               = local.instance_role_name
+  assume_role_policy = data.aws_iam_policy_document.instance_iam_role_assume_permissions.json
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.environment_name
+    }
+  )
+}
+
+# Attach managed policy to the role
+resource "aws_iam_role_policy_attachment" "instance_iam_policy_attach_amazonssmmanagedinstancecore" {
+  role       = aws_iam_role.instance_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Create the instance profile (referenced by the aws_instance)
+resource "aws_iam_instance_profile" "instance_profile" {
+  name = local.instance_role_name
+  role = aws_iam_role.instance_iam_role.name
+}

--- a/service-bastion/iam.tf
+++ b/service-bastion/iam.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "instance_iam_role_assume_permissions" {
   statement {
     effect = "Allow"
     actions = [
-      "sts.AssumeRole"
+      "sts:AssumeRole"
     ]
     principals {
       type        = "Service"
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "instance_iam_role_assume_permissions" {
 resource "aws_iam_role" "instance_iam_role" {
   name               = local.instance_role_name
   assume_role_policy = data.aws_iam_policy_document.instance_iam_role_assume_permissions.json
+  description        = "Allows EC2 instances to call AWS services on your behalf."
   tags = merge(
     var.tags,
     {

--- a/service-bastion/main.tf
+++ b/service-bastion/main.tf
@@ -38,10 +38,11 @@ data "aws_ami" "hmpps" {
 }
 
 resource "aws_instance" "bastion_instance" {
-  ami           = data.aws_ami.hmpps.id
-  instance_type = "t2.micro"
-  key_name      = module.bastion_ssh_key.deployer_key
-  subnet_id     = data.terraform_remote_state.bastion_vpc.outputs.bastion-public-subnet-az1
+  ami                  = data.aws_ami.hmpps.id
+  instance_type        = "t2.micro"
+  key_name             = module.bastion_ssh_key.deployer_key
+  subnet_id            = data.terraform_remote_state.bastion_vpc.outputs.bastion-public-subnet-az1
+  iam_instance_profile = aws_iam_instance_profile.instance_profile.name
 
   vpc_security_group_ids = [
     data.terraform_remote_state.bastion_vpc.outputs.bastion_vpc_sg_id,


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-306

Adding IaC for the IAM role (attached managed policy and trust relationship) and instance profile for the bastions.
These changes have already been done in dev through the console, with nothing done in prod.

So for dev, we should import the resources into state.
Given the jenkins pipeline is not trustworthy and only local TF operations seem to succeed, in dev, the plan would be
1. Take a back of the state file
2. Run
```
ENVIRONMENT=eng-dev COMPONENT=service-bastion tg import 'aws_iam_instance_profile.instance_profile' SSMBastionAccess
ENVIRONMENT=eng-dev COMPONENT=service-bastion tg import 'aws_iam_role.instance_iam_role' SSMBastionAccess
ENVIRONMENT=eng-dev COMPONENT=service-bastion tg import 'aws_iam_role_policy_attachment.instance_iam_policy_attach_amazonssmmanagedinstancecore' SSMBastionAccess/arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
```
3. Run a terraform plan to confirm desired state = actual state

Changes can be locally applied in prod.