### PR TITLE
Add in security group rule in dev to allow jenkins access

### DIFF
--- a/bastion-vpc/security-groups.tf
+++ b/bastion-vpc/security-groups.tf
@@ -26,6 +26,19 @@ resource "aws_security_group_rule" "ssh_in" {
   type              = "ingress"
 }
 
+# Create this rule in the eng-dev account to allow the jenkins master and agents to connect to dev bastion over tcp 22
+#   Rather than having to go over the internet
+resource "aws_security_group_rule" "ssh_in_from_jenkins" {
+  count                    = var.environment_name == "bastion-dev" ? 1 : 0
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.bastion-vpc-sg.id
+  to_port                  = 22
+  cidr_blocks              = [var.eng_dev_vpc_cidr]
+  type                     = "ingress"
+  description              = "Allow access from eng-dev vpc to allow Jenkins to connect"
+}
+
 # Only create this SG rule if not in the eng-dev account
 #   In time, this will be excluded for both eng-dev and eng-prod
 resource "aws_security_group_rule" "https_in" {

--- a/bastion-vpc/variables.tf
+++ b/bastion-vpc/variables.tf
@@ -50,3 +50,6 @@ variable "bastion_peering_ids" {
   type = list(string)
 }
 
+variable "eng_dev_vpc_cidr" {
+  description = "CIDR range of eng_dev VPC hosting jenkins, jira etc. This used to allow jenkins instances to reach dev and prod bastion"
+}

--- a/env_configs/common.tfvars
+++ b/env_configs/common.tfvars
@@ -10,3 +10,6 @@ availability_zone = {
 }
 
 lb_account_id = "652711504416"
+
+# CIDR range of eng_dev VPC hosting jenkins, jira etc. This used to allow jenkins instances to reach dev and prod bastion 
+eng_dev_vpc_cidr = "10.161.96.0/24"


### PR DESCRIPTION
Work item: nit 452.

Add sec group rule to allow connectivity from eng-dev VPC and specifically Jenkins.
