### PR TITLE
NIT-454 added missing variable

### DIFF
--- a/env_configs/prod.tfvars
+++ b/env_configs/prod.tfvars
@@ -1,4 +1,5 @@
 bastion_domain_zone = "bastion-prod.probation.hmpps.dsd.io."
+bastion_domain_name = "bastion-prod.probation.hmpps.dsd.io"
 
 bastion_cidr_block = "10.160.98.0/25"
 


### PR DESCRIPTION
This variable is required to run terraform against production, which has been neglected for too long. Please note the the value aligns it with the config for dev, but the DNS name is not in use